### PR TITLE
chore: remove URL Shortener

### DIFF
--- a/.github/workflows/a11ywatch.yml
+++ b/.github/workflows/a11ywatch.yml
@@ -19,7 +19,6 @@ jobs:
           - https://staging.notification.cdssandbox.xyz
           - https://forms-staging.cdssandbox.xyz
           - https://design.alpha.canada.ca/en/
-          - https://url-shortener.cdssandbox.xyz/
           - https://design-system.alpha.canada.ca/en/
           - https://saas.cdssandbox.xyz/en/ 
     steps:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -19,7 +19,6 @@ jobs:
           - https://staging.notification.cdssandbox.xyz
           - https://forms-staging.cdssandbox.xyz
           - https://design.alpha.canada.ca/en/
-          - https://url-shortener.cdssandbox.xyz/
           - https://design-system.alpha.canada.ca/en/
           - https://saas.cdssandbox.xyz/en/
     steps:

--- a/.github/workflows/nuclei-default.yml
+++ b/.github/workflows/nuclei-default.yml
@@ -19,7 +19,6 @@ jobs:
           - https://staging.notification.cdssandbox.xyz
           - https://forms-staging.cdssandbox.xyz
           - https://design.alpha.canada.ca/en/
-          - https://url-shortener.cdssandbox.xyz/
           - https://design-system.alpha.canada.ca/en/
           - https://saas.cdssandbox.xyz/en/ 
     steps:

--- a/.github/workflows/oswasp-zap-default.yml
+++ b/.github/workflows/oswasp-zap-default.yml
@@ -14,8 +14,6 @@ jobs:
         domain:
           - https://encrypted-message.cdssandbox.xyz
           - http://encrypted-message.cdssandbox.xyz
-          - https://url-shortener.cdssandbox.xyz
-          - http://url-shortener.cdssandbox.xyz
           - https://staging.notification.cdssandbox.xyz
           - http://staging.notification.cdssandbox.xyz
     steps:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,5 @@ The purpose of this repository is to coordinate the automatic scanning of CDS we
 |[https://staging.notification.cdssandbox.xyz](https://staging.notification.cdssandbox.xyz)|✅|✅|✅|⭕️|
 |[https://forms-staging.cdssandbox.xyz](https://forms-staging.cdssandbox.xyz)|✅|✅|✅|✅|
 |[https://design.alpha.canada.ca/en/](https://design.alpha.canada.ca/en/)|✅|✅|✅|⭕️|
-|[https://url-shortener.cdssandbox.xyz/](https://url-shortener.cdssandbox.xyz/)|✅|✅|✅|✅|
 |[https://design-system.alpha.canada.ca/en/](https://design.alpha.canada.ca/en/)|✅|✅|✅|⭕️|
 |[https://saas.cdssandbox.xyz/en/](https://saas.cdssandbox.xyz/en/)|✅|✅|✅|⭕️|


### PR DESCRIPTION
# Summary
Remove URL Shortener scans as the service has been shut down.

# Related
- cds-snc/platform-core-services#449