### PR TITLE
fix: nuclei and a11ywatch scans

### DIFF
--- a/.github/workflows/a11ywatch.yml
+++ b/.github/workflows/a11ywatch.yml
@@ -22,7 +22,7 @@ jobs:
           - https://design-system.alpha.canada.ca/en/
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
-      - uses: a11ywatch/github-action@75b2d0bbb437086f9991c768b2654620fe0024c3 # v1.15.0
+      - uses: a11ywatch/github-action@d61a01aad49cc54db0a669cc61b7e85f08994162 # v2.1.10
         with:
           WEBSITE_URL: ${{ matrix.domain }}
           DISABLE_PR_STATS: true

--- a/.github/workflows/nuclei-default.yml
+++ b/.github/workflows/nuclei-default.yml
@@ -26,8 +26,7 @@ jobs:
         uses: projectdiscovery/nuclei-action@main
         with:
           target: ${{ matrix.domain }}
-          flags: "-stats"
-          json: true
+          flags: "-json-export -stats"
       - name: Forward results to Sentinel
         uses: cds-snc/sentinel-forward-data-action@main
         with:


### PR DESCRIPTION
# Summary
Update to latest version of a11ywatch GitHub action.

Update how JSON export is created for the nuclei scan.