### PR TITLE
fix: remove old product URLs

### DIFF
--- a/.github/workflows/a11ywatch.yml
+++ b/.github/workflows/a11ywatch.yml
@@ -12,13 +12,11 @@ jobs:
       matrix:
         domain:
           - https://digital.canada.ca
-          - https://learning-resources.cdssandbox.xyz
           - https://numerique.canada.ca
           - https://encrypted-message.cdssandbox.xyz
           - https://articles.cdssandbox.xyz
           - https://staging.notification.cdssandbox.xyz
           - https://forms-staging.cdssandbox.xyz
-          - https://design.alpha.canada.ca/en/
           - https://design-system.alpha.canada.ca/en/
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -12,13 +12,11 @@ jobs:
       matrix:
         domain:
           - https://digital.canada.ca
-          - https://learning-resources.cdssandbox.xyz
           - https://numerique.canada.ca
           - https://encrypted-message.cdssandbox.xyz
           - https://articles.cdssandbox.xyz
           - https://staging.notification.cdssandbox.xyz
           - https://forms-staging.cdssandbox.xyz
-          - https://design.alpha.canada.ca/en/
           - https://design-system.alpha.canada.ca/en/
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0

--- a/.github/workflows/nuclei-default.yml
+++ b/.github/workflows/nuclei-default.yml
@@ -12,13 +12,11 @@ jobs:
       matrix:
         domain:
           - https://digital.canada.ca
-          - https://learning-resources.cdssandbox.xyz
           - https://numerique.canada.ca
           - https://encrypted-message.cdssandbox.xyz
           - https://articles.cdssandbox.xyz
           - https://staging.notification.cdssandbox.xyz
           - https://forms-staging.cdssandbox.xyz
-          - https://design.alpha.canada.ca/en/
           - https://design-system.alpha.canada.ca/en/
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871

--- a/README.md
+++ b/README.md
@@ -6,11 +6,9 @@ The purpose of this repository is to coordinate the automatic scanning of CDS we
 | Site | [A11yWatch](https://github.com/a11ywatch/github-actions) | [Lighthouse](https://github.com/treosh/lighthouse-ci-action) | [Nuclei](https://github.com/projectdiscovery/nuclei-action) | [OWASP-Zap](https://github.com/zaproxy/action-full-scan) |
 |---|---|---|---|---|
 |[https://digital.canada.ca/](https://digital.canada.ca/)|✅|✅|✅|⭕️|
-|[https://learning-resources.cdssandbox.xyz](https://learning-resources.cdssandbox.xyz)|✅|✅|✅|⭕️|
 |[https://numerique.canada.ca/](https://numerique.canada.ca/)|✅|✅|✅|⭕️|
 |[https://encrypted-message.cdssandbox.xyz/](https://encrypted-message.cdssandbox.xyz/)|✅|✅|✅|✅|
 |[https://articles.cdssandbox.xyz](https://articles.cdssandbox.xyz/)|✅|✅|✅|⭕️|
 |[https://staging.notification.cdssandbox.xyz](https://staging.notification.cdssandbox.xyz)|✅|✅|✅|✅|
 |[https://forms-staging.cdssandbox.xyz](https://forms-staging.cdssandbox.xyz)|✅|✅|✅|⭕️|
-|[https://design.alpha.canada.ca/en/](https://design.alpha.canada.ca/en/)|✅|✅|✅|⭕️|
 |[https://design-system.alpha.canada.ca/en/](https://design.alpha.canada.ca/en/)|✅|✅|✅|⭕️|


### PR DESCRIPTION
# Summary
Remove old product URLs from the the lighthouse, nuclei and a11ywatch scans.