### PR TITLE
fix: set a11ywatch timeout and remove Forms staging

### DIFF
--- a/.github/workflows/a11ywatch.yml
+++ b/.github/workflows/a11ywatch.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   a11ywatch-ci-action:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -16,7 +17,6 @@ jobs:
           - https://encrypted-message.cdssandbox.xyz
           - https://articles.cdssandbox.xyz
           - https://staging.notification.cdssandbox.xyz
-          - https://forms-staging.cdssandbox.xyz
           - https://design-system.alpha.canada.ca/en/
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0

--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ The purpose of this repository is to coordinate the automatic scanning of CDS we
 |[https://encrypted-message.cdssandbox.xyz/](https://encrypted-message.cdssandbox.xyz/)|✅|✅|✅|✅|
 |[https://articles.cdssandbox.xyz](https://articles.cdssandbox.xyz/)|✅|✅|✅|⭕️|
 |[https://staging.notification.cdssandbox.xyz](https://staging.notification.cdssandbox.xyz)|✅|✅|✅|✅|
-|[https://forms-staging.cdssandbox.xyz](https://forms-staging.cdssandbox.xyz)|✅|✅|✅|⭕️|
+|[https://forms-staging.cdssandbox.xyz](https://forms-staging.cdssandbox.xyz)|⭕️|✅|✅|⭕️|
 |[https://design-system.alpha.canada.ca/en/](https://design.alpha.canada.ca/en/)|✅|✅|✅|⭕️|


### PR DESCRIPTION
# Summary
Update the a11ywatch workflow so that it times out after 20 minutes. Also remove the Forms staging scan as it hangs and detects no pages.