### PR TITLE
Adding gc signin website to automatic website scanning

### DIFF
--- a/.github/workflows/a11ywatch.yml
+++ b/.github/workflows/a11ywatch.yml
@@ -18,6 +18,7 @@ jobs:
           - https://articles.cdssandbox.xyz
           - https://staging.notification.cdssandbox.xyz
           - https://design-system.alpha.canada.ca/en/
+          - https://app.gc-signin.cdssandbox.xyz/
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - uses: a11ywatch/github-action@d61a01aad49cc54db0a669cc61b7e85f08994162 # v2.1.10

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -18,6 +18,7 @@ jobs:
           - https://staging.notification.cdssandbox.xyz
           - https://forms-staging.cdssandbox.xyz
           - https://design-system.alpha.canada.ca/en/
+          - https://app.gc-signin.cdssandbox.xyz/
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0

--- a/.github/workflows/nuclei-default.yml
+++ b/.github/workflows/nuclei-default.yml
@@ -18,6 +18,7 @@ jobs:
           - https://staging.notification.cdssandbox.xyz
           - https://forms-staging.cdssandbox.xyz
           - https://design-system.alpha.canada.ca/en/
+          - https://app.gc-signin.cdssandbox.xyz/
     steps:
       - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
       - name: Nuclei - Vulnerability Scan

--- a/.github/workflows/oswasp-zap-default.yml
+++ b/.github/workflows/oswasp-zap-default.yml
@@ -16,6 +16,7 @@ jobs:
           - http://encrypted-message.cdssandbox.xyz
           - https://staging.notification.cdssandbox.xyz
           - http://staging.notification.cdssandbox.xyz
+          - https://app.gc-signin.cdssandbox.xyz/
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ The purpose of this repository is to coordinate the automatic scanning of CDS we
 |[https://staging.notification.cdssandbox.xyz](https://staging.notification.cdssandbox.xyz)|✅|✅|✅|✅|
 |[https://forms-staging.cdssandbox.xyz](https://forms-staging.cdssandbox.xyz)|⭕️|✅|✅|⭕️|
 |[https://design-system.alpha.canada.ca/en/](https://design.alpha.canada.ca/en/)|✅|✅|✅|⭕️|
+|[https://app.gc-signin.cdssandbox.xyz/](https://app.gc-signin.cdssandbox.xyz/)|✅|✅|✅|✅|


### PR DESCRIPTION
# Summary | Résumé

Adding GC SignIn Dev website [https://app.gc-signin.cdssandbox.xyz/](https://app.gc-signin.cdssandbox.xyz/) to automatic website scanning.