### PR TITLE
fix: Nuclei action to send JSON output to Sentinel

### DIFF
--- a/.github/workflows/nuclei-default.yml
+++ b/.github/workflows/nuclei-default.yml
@@ -11,6 +11,14 @@ jobs:
       fail-fast: false
       matrix:
         domain:
+          - https://digital.canada.ca
+          - https://numerique.canada.ca
+          - https://encrypted-message.cdssandbox.xyz
+          - https://articles.cdssandbox.xyz
+          - https://staging.notification.cdssandbox.xyz
+          - https://forms-staging.cdssandbox.xyz
+          - https://design-system.alpha.canada.ca/en/
+          - https://app.gc-signin.cdssandbox.xyz/
           - https://superset.cdssandbox.xyz/
     steps:
       - name: Checkout
@@ -21,7 +29,7 @@ jobs:
         with:
           target: ${{ matrix.domain }}
           nuclei-version: "3.4.10"
-          flags: "-jsonl -jsonl-export nuclei.log -severity critical,high,medium,low,info -stats"
+          flags: "-jsonl -jsonl-export nuclei.log -severity critical,high,medium,low -stats"
 
       - name: Forward results to Sentinel
         uses: cds-snc/sentinel-forward-data-action@main

--- a/.github/workflows/nuclei-default.yml
+++ b/.github/workflows/nuclei-default.yml
@@ -21,12 +21,16 @@ jobs:
           - https://app.gc-signin.cdssandbox.xyz/
           - https://superset.cdssandbox.xyz/
     steps:
-      - uses: actions/checkout@8edcb1bdb4e267140fa742c62e395cd74f332709
+      - name: Checkout
+        uses: actions/checkout@8edcb1bdb4e267140fa742c62e395cd74f332709
+
       - name: Nuclei - Vulnerability Scan
-        uses: projectdiscovery/nuclei-action@main
+        uses: projectdiscovery/nuclei-action@6a69b5015a4059e8804afcb33ff5e56bfd546908 # v2.0.1
         with:
           target: ${{ matrix.domain }}
-          flags: "-json-export -stats"
+          json: true
+          flags: "-severity critical,high,medium,low -stats"
+ 
       - name: Forward results to Sentinel
         uses: cds-snc/sentinel-forward-data-action@main
         with:

--- a/.github/workflows/nuclei-default.yml
+++ b/.github/workflows/nuclei-default.yml
@@ -28,9 +28,9 @@ jobs:
         uses: projectdiscovery/nuclei-action@6a69b5015a4059e8804afcb33ff5e56bfd546908 # v2.0.1
         with:
           target: ${{ matrix.domain }}
-          json: true
-          flags: "-severity critical,high,medium,low -stats"
- 
+          nuclei-version: "3.4.10"
+          flags: "-jsonl -jsonl-export nuclei.log -severity critical,high,medium,low -stats"
+
       - name: Forward results to Sentinel
         uses: cds-snc/sentinel-forward-data-action@main
         with:

--- a/.github/workflows/nuclei-default.yml
+++ b/.github/workflows/nuclei-default.yml
@@ -11,14 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         domain:
-          - https://digital.canada.ca
-          - https://numerique.canada.ca
-          - https://encrypted-message.cdssandbox.xyz
-          - https://articles.cdssandbox.xyz
-          - https://staging.notification.cdssandbox.xyz
-          - https://forms-staging.cdssandbox.xyz
-          - https://design-system.alpha.canada.ca/en/
-          - https://app.gc-signin.cdssandbox.xyz/
           - https://superset.cdssandbox.xyz/
     steps:
       - name: Checkout
@@ -29,7 +21,7 @@ jobs:
         with:
           target: ${{ matrix.domain }}
           nuclei-version: "3.4.10"
-          flags: "-jsonl -jsonl-export nuclei.log -severity critical,high,medium,low -stats"
+          flags: "-jsonl -jsonl-export nuclei.log -severity critical,high,medium,low,info -stats"
 
       - name: Forward results to Sentinel
         uses: cds-snc/sentinel-forward-data-action@main


### PR DESCRIPTION
# Summary
Update the Nuclei action to write results as JSON and pin the action version to prevent unexpected changes in the future.
