### PR TITLE
Changing urls for login canada

### DIFF
--- a/.github/workflows/a11ywatch.yml
+++ b/.github/workflows/a11ywatch.yml
@@ -18,10 +18,8 @@ jobs:
           - https://articles.cdssandbox.xyz
           - https://staging.notification.cdssandbox.xyz
           - https://design-system.alpha.canada.ca/en/
-          - http://sign-in.alpha.canada.ca/
+          - https://login.alpha.canada.ca/
           - http://connexion.alpha.canada.ca/
-          - https://sign-in.canada.ca
-          - https://connexion.canada.ca
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - uses: a11ywatch/github-action@d61a01aad49cc54db0a669cc61b7e85f08994162 # v2.1.10 (includes commit to upgrade upload-artifact github action to v4 as v3 is deprecated)

--- a/.github/workflows/a11ywatch.yml
+++ b/.github/workflows/a11ywatch.yml
@@ -20,6 +20,7 @@ jobs:
           - https://design-system.alpha.canada.ca/en/
           - https://login.alpha.canada.ca/
           - http://connexion.alpha.canada.ca/
+          - https://app.login-connexion.alpha.canada.ca/
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - uses: a11ywatch/github-action@d61a01aad49cc54db0a669cc61b7e85f08994162 # v2.1.10 (includes commit to upgrade upload-artifact github action to v4 as v3 is deprecated)

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -18,10 +18,8 @@ jobs:
           - https://staging.notification.cdssandbox.xyz
           - https://forms-staging.cdssandbox.xyz
           - https://design-system.alpha.canada.ca/en/
-          - http://sign-in.alpha.canada.ca
+          - https://login.alpha.canada.ca/
           - http://connexion.alpha.canada.ca
-          - https://sign-in.canada.ca
-          - https://connexion.canada.ca
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3.6.1

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -20,6 +20,7 @@ jobs:
           - https://design-system.alpha.canada.ca/en/
           - https://login.alpha.canada.ca/
           - http://connexion.alpha.canada.ca
+          - https://app.login-connexion.alpha.canada.ca/
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3.6.1

--- a/.github/workflows/nuclei-default.yml
+++ b/.github/workflows/nuclei-default.yml
@@ -19,10 +19,8 @@ jobs:
           - https://forms-staging.cdssandbox.xyz
           - https://design-system.alpha.canada.ca/en/
           - https://superset.cdssandbox.xyz/
-          - http://sign-in.alpha.canada.ca/
+          - https://login.alpha.canada.ca/
           - http://connexion.alpha.canada.ca/
-          - https://sign-in.canada.ca
-          - https://connexion.canada.ca
     steps:
       - name: Checkout
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98

--- a/.github/workflows/nuclei-default.yml
+++ b/.github/workflows/nuclei-default.yml
@@ -21,6 +21,7 @@ jobs:
           - https://superset.cdssandbox.xyz/
           - https://login.alpha.canada.ca/
           - http://connexion.alpha.canada.ca/
+          - https://app.login-connexion.alpha.canada.ca/
     steps:
       - name: Checkout
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98

--- a/.github/workflows/oswasp-zap-default.yml
+++ b/.github/workflows/oswasp-zap-default.yml
@@ -19,6 +19,7 @@ jobs:
           - https://superset.cdssandbox.xyz/
           - https://login.alpha.canada.ca/
           - http://connexion.alpha.canada.ca/
+          - https://app.login-connexion.alpha.canada.ca/
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/oswasp-zap-default.yml
+++ b/.github/workflows/oswasp-zap-default.yml
@@ -17,10 +17,8 @@ jobs:
           - https://staging.notification.cdssandbox.xyz
           - http://staging.notification.cdssandbox.xyz
           - https://superset.cdssandbox.xyz/
-          - http://sign-in.alpha.canada.ca/
+          - https://login.alpha.canada.ca/
           - http://connexion.alpha.canada.ca/
-          - https://sign-in.canada.ca
-          - https://connexion.canada.ca
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0


### PR DESCRIPTION
# Summary | Résumé

Changing the urls in Sign In Canada for the automatic website scanning based on ticket #113. Additionally, adding new domain #114 